### PR TITLE
商品情報編集機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
   before_action :redirect_if_not_owner, only: [:edit]
+  before_action :set_item, only: [:show, :edit, :update]
   def index
     @items = Item.order(created_at: :desc)
   end
@@ -10,11 +11,9 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def create
@@ -27,13 +26,13 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to @item
     else
       render :edit
     end
   end
+
   private
 
   def item_params
@@ -46,5 +45,9 @@ class ItemsController < ApplicationController
     redirect_to root_path unless user_signed_in? && item.user_id == current_user.id
   rescue ActiveRecord::RecordNotFound
     redirect_to root_path
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
-  before_action :redirect_if_not_owner, only: [:edit]
   before_action :set_item, only: [:show, :edit, :update]
+  before_action :redirect_if_not_owner, only: [:edit]
+ 
   def index
     @items = Item.order(created_at: :desc)
   end
@@ -39,7 +40,7 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:product_name, :origin_location_id, :shipping_address_form_id, :shipping_fee_id, :category_id,
                                  :price, :image, :product_description, :product_condition_id).merge(user_id: current_user.id)
   end
-  
+
   def redirect_if_not_owner
     item = Item.find(params[:id])
     redirect_to root_path unless user_signed_in? && item.user_id == current_user.id

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new]
-
+  before_action :authenticate_user!, only: [:new, :edit]
+  before_action :redirect_if_not_owner, only: [:edit]
   def index
     @items = Item.order(created_at: :desc)
   end
@@ -10,6 +10,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    @item = Item.find(params[:id])
   end
 
   def show
@@ -25,10 +26,25 @@ class ItemsController < ApplicationController
     end
   end
 
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to @item
+    else
+      render :edit
+    end
+  end
   private
 
   def item_params
     params.require(:item).permit(:product_name, :origin_location_id, :shipping_address_form_id, :shipping_fee_id, :category_id,
                                  :price, :image, :product_description, :product_condition_id).merge(user_id: current_user.id)
+  end
+  
+  def redirect_if_not_owner
+    item = Item.find(params[:id])
+    redirect_to root_path unless user_signed_in? && item.user_id == current_user.id
+  rescue ActiveRecord::RecordNotFound
+    redirect_to root_path
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -42,8 +42,7 @@ class ItemsController < ApplicationController
   end
 
   def redirect_if_not_owner
-    item = Item.find(params[:id])
-    redirect_to root_path unless user_signed_in? && item.user_id == current_user.id
+    redirect_to root_path unless user_signed_in? && @item.user_id == current_user.id
   rescue ActiveRecord::RecordNotFound
     redirect_to root_path
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -43,8 +43,6 @@ class ItemsController < ApplicationController
 
   def redirect_if_not_owner
     redirect_to root_path unless user_signed_in? && @item.user_id == current_user.id
-  rescue ActiveRecord::RecordNotFound
-    redirect_to root_path
   end
 
   def set_item

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,13 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with(model: @item, url: item_path(@item), method: :patch, data: { turbo: false }, local: true) do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
-    <%# 商品画像 %>
+    <%= render 'shared/error_messages', model: f.object %>
+   
     <div class="img-upload">
       <div class="weight-bold-text">
         商品画像
@@ -23,7 +20,8 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
+         
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :product_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :product_description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:product_condition_id, ProductCondition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_fee_id, ShippingFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:origin_location_id, OriginLocation.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_address_form_id, ShippingAddressForm.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -140,8 +138,8 @@ app/assets/stylesheets/items/new.css %>
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= f.submit "変更する", class: "sell-btn" %>
+      <%= link_to 'もどる', item_path(@item.id), class: "back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
 
   <% if user_signed_in? %> 
     <% if same_user?(current_user, @item) %>
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <%= link_to "商品の編集",edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:new, :edit, :index, :show, :create]
+  resources :items, only: [:new, :edit, :index, :show, :create, :update]
 end


### PR DESCRIPTION
# What
商品情報編集機能の設定

# Why
商品情報編集機能実装のため

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/e87271a8e064ff3344e07ffe4f7fe465

 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/d660576aca717f5c66d9e882ba556267

 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画　　https://gyazo.com/8a56c640ff156c0a35f00171e4457d6a

 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/f51aa36cc4ee08946a6f8a6d5f8a7c14

 ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
 https://gyazo.com/41fc9d222fb0da113685c1b09f6a740f

 ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/3bb32f7190aca06ee2bc6328bc1c18b1

 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/6d2da63537a968bc7d7943acb07bafbf